### PR TITLE
Add link to libbpfgo package

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -348,6 +348,9 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/iovisor/gobpf">
               <b>gobpf</b>
             </a>{" "}
+            <a href="https://github.com/aquasecurity/libbpfgo">
+              <b>libbpfgo</b>
+            </a>{" "}
           </p>
           <p>
             <a href="https://github.com/cilium/ebpf">eBPF</a> is designed as a

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -360,6 +360,10 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/iovisor/gobpf">gobpf</a> is a CGo-based
             library which provides Go bindings for the BCC framework as well as
             low-level routines to load and use eBPF programs from ELF files.
+            <a href="https://github.com/aquasecurity/libbpfgo">libbpfgo</a> is a
+            Go wrapper around libbpf. It supports BPF CO-RE and its goal is to 
+            be a complete implementation of libbpf APIs. It uses CGo to call 
+            into linked versions of libbpf. 
           </p>
         </div>
       </div>


### PR DESCRIPTION
This adds a link to [libbpfgo](https://github.com/aquasecurity/libbpfgo) under Go packages.

Note that I can't figure out my local environment to host the webserver (no experience with yarn, or JS for that matter) so of course please make sure I didn't mess something up :D 

Signed-off-by: grantseltzer <grantseltzer@gmail.com>