### PR TITLE
Explain the acronym in the about page (alternative approach)

### DIFF
--- a/src/pages/what-is-ebpf.js
+++ b/src/pages/what-is-ebpf.js
@@ -72,7 +72,7 @@ class Description extends React.Component {
           <h1>eBPF Documentation</h1>
           <h2>What is eBPF?</h2>
     <p>
-      eBPF is a revolutionary technology with origins in the Linux kernel that can run sandboxed programs in an operating system kernel. It is used to safely and efficiently extend the capabilities of the kernel without requiring to change kernel source code or load kernel modules.
+      eBPF (which is no longer an acronym for anything) is a revolutionary technology with origins in the Linux kernel that can run sandboxed programs in a privileged context such as the operating system kernel. It is used to safely and efficiently extend the capabilities of the kernel without requiring to change kernel source code or load kernel modules.
     </p>
     <p>
       Historically, the operating system has always been an ideal place to implement observability, security, and networking functionality due to the kernel’s privileged ability to oversee and control the entire system. At the same time, an operating system kernel is hard to evolve due to its central role and high requirement towards stability and security. The rate of innovation at the operating system level has thus traditionally been lower compared to functionality implemented outside of the operating system.


### PR DESCRIPTION
PR #118 originally made one proposal, but I agree with Paul's
feedback on that PR, and propose this alternative instead.

Besides explaining the acronym, it updates the language about
the kernel to just use the kernel as the prominent example,
since there are projects that run eBPF programs in userspace
to extend userspace daemons, in FPGAs, etc.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>