### PR TITLE
Add Major/Emerging labels

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -64,7 +64,7 @@ const RequirementsList = () => (
 
 const ProjectDescriptions = () => (
   <div className="project-descriptions">
-    <TitleWithAnchor headerClassName="projects-title projects-common-title">Major Projects</TitleWithAnchor>
+    <TitleWithAnchor headerClassName="projects-title projects-common-title">Applications (Major)</TitleWithAnchor>
 
     <div className="project-box">
       <TitleWithAnchor headerClassName="project-major-title projects-common-title" headerTag="h3">bcc</TitleWithAnchor>
@@ -235,7 +235,7 @@ const ProjectDescriptions = () => (
       </div>
     </div>
 
-    <TitleWithAnchor headerClassName="projects-title projects-common-title">Core Infrastructure</TitleWithAnchor>
+    <TitleWithAnchor headerClassName="projects-title projects-common-title">Core Infrastructure (Major)</TitleWithAnchor>
 
     <div className="project-box">
       <TitleWithAnchor headerClassName="project-major-title projects-common-title" headerTag="h3">Linux Kernel</TitleWithAnchor>
@@ -331,6 +331,8 @@ const ProjectDescriptions = () => (
       </div>
     </div>
 
+    <TitleWithAnchor headerClassName="projects-title projects-common-title">Core Infrastructure (Emerging)</TitleWithAnchor>
+
     <TitleWithAnchor headerClassName="projects-title projects-common-title" className="projects-title">eBPF Libraries</TitleWithAnchor>
 
     <div className="project-box">
@@ -341,6 +343,7 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
+            Major:
             <a href="https://github.com/cilium/ebpf">
               <b>ebpf</b>
             </a>{" "}
@@ -348,6 +351,7 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/iovisor/gobpf">
               <b>gobpf</b>
             </a>{" "}
+            Emerging:
             <a href="https://github.com/aquasecurity/libbpfgo">
               <b>libbpfgo</b>
             </a>{" "}
@@ -356,7 +360,9 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/cilium/ebpf">eBPF</a> is designed as a
             pure Go library that provides utilities for loading, compiling, and
             debugging eBPF programs. It has minimal external dependencies and is
-            intended to be used in long running processes. The{" "}
+            intended to be used in long running processes.
+          </p>
+          <p>
             <a href="https://github.com/iovisor/gobpf">gobpf</a> is a CGo-based
             library which provides Go bindings for the BCC framework as well as
             low-level routines to load and use eBPF programs from ELF files.
@@ -377,9 +383,11 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
+            Major:
             <a href="https://github.com/libbpf/libbpf">
               <b>libbpf</b>
             </a>{" "}
+            Emerging:
           </p>
           <p>
             libbpf is a C/C++ based library which is maintained as part of the
@@ -406,6 +414,7 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
+            Major:
             <a href="https://github.com/libbpf/libbpf-rs">
               <b>libbpf-rs</b>
             </a>{" "}
@@ -413,12 +422,15 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/redsift/redbpf">
               <b>redbpf</b>
             </a>{" "}
+            Emerging:
           </p>
           <p>
             <a href="https://github.com/libbpf/libbpf-rs">libbpf-rs</a> is a
             safe, idiomatic, and opinionated wrapper API around libbpf written
             in Rust. libbpf-rs, together with libbpf-cargo (libbpf cargo plugin)
-            allows to write 'compile once run everywhere' (CO-RE) eBPF programs.{" "}
+            allows to write 'compile once run everywhere' (CO-RE) eBPF programs.
+          </p>
+          <p>
             <a href="https://github.com/redsift/redbpf">redbpf</a> is a Rust
             eBPF toolchain that contains a collection of Rust libraries to work
             with eBPF programs.
@@ -427,7 +439,7 @@ const ProjectDescriptions = () => (
       </div>
     </div>
 
-    <TitleWithAnchor headerClassName="projects-title projects-common-title">Emerging Projects</TitleWithAnchor>
+    <TitleWithAnchor headerClassName="projects-title projects-common-title">Applications (Emerging)</TitleWithAnchor>
 
     <div className="project-box">
       <TitleWithAnchor headerClassName="project-major-title projects-common-title" headerTag="h3">Hubble</TitleWithAnchor>


### PR DESCRIPTION
This is the first step in a series of changes, split to ease code
review.

Applications already had two sections, which unfortunately
are not adjacent on the page, so this PR just adds the Applications
label to the two sections.  This could have moved the sections around
to put them adjacent but that would have made this PR harder to review,
so leaving it for a separate PR.

The other sections did not have any major/emerging distinction, so this adds
a grouping within each other category.  Currently however the stylesheet
only has two levels of TitleWithAnchor headings where we really need three.
There is currently an inconsistency in terms of style where application
projects use one style and eBPF library projects use a different style.
This PR does not change that yet either, it merely adds labels within
the style that exists for each category.  A future PR should create a
third level and update the styles to be consistent.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>