### PR TITLE
Remove project-specific logo from general ebpf.io page header

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -97,13 +97,6 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
           {languageButtons}
         </span>
       </span>}
-      <a href="https://www.cilium.io">
-        <img
-          src={require("../assets/cilium_logo.png")}
-          width="46px"
-          height="50px"
-        />
-      </a>
     </nav>
   </div>
 };
@@ -177,9 +170,6 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
               {languageButtons}
             </span>
           </span>}
-          <a href="https://www.cilium.io">
-            <img src={require("../assets/cilium_logo.png")} height="50px" />
-          </a>
         </nav>
       )}
     </div>


### PR DESCRIPTION
Since ebpf.io was donated to the eBPF Foundation and is no longer an
Isovalent site per se, it doesn't make sense to have the Cilium logo
(or any other project-specific logo) on the main page.  That's what
the Projects page is for.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>