### PR TITLE
projects: improve formatting for the "Major:"/"Emerging:" fields

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -378,11 +378,12 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
-            Major:
+            <b>Major:</b>{" "}
             <a href="https://github.com/cilium/ebpf">
               <b>ebpf</b>
             </a>{" "}
-            Emerging:
+            <br />
+            <b>Emerging:</b>{" "}
             <a href="https://github.com/aquasecurity/libbpfgo">
               <b>libbpfgo</b>
             </a>{" "}
@@ -411,11 +412,12 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
-            Major:
+            <b>Major:</b>{" "}
             <a href="https://github.com/libbpf/libbpf">
               <b>libbpf</b>
             </a>{" "}
-            Emerging:
+            <br />
+            <b>Emerging:</b>{" "}
           </p>
           <p>
             libbpf is a C/C++ based library which is maintained as part of the
@@ -442,7 +444,7 @@ const ProjectDescriptions = () => (
         </div>
         <div className="project-description">
           <p>
-            Major:
+            <b>Major:</b>{" "}
             <a href="https://github.com/libbpf/libbpf-rs">
               <b>libbpf-rs</b>
             </a>{" "}
@@ -450,7 +452,8 @@ const ProjectDescriptions = () => (
             <a href="https://github.com/redsift/redbpf">
               <b>redbpf</b>
             </a>{" "}
-            Emerging:
+            <br />
+            <b>Emerging:</b>{" "}
             <a href="https://github.com/aya-rs/aya">
               <b>Aya</b>
             </a>{" "}


### PR DESCRIPTION
On the `eBPF libraries` section of the `Projects` page, improve formatting by:

- Adding a space after the colons in `Major:` and `Emerging:`
- Inserting a line break between the major and the emerging projects
- Setting `Major:` and `Emerging:` in bold, just as for the names of the libraries, in order to better dissociate from the descriptions under them.

Before:
![before](https://user-images.githubusercontent.com/17001771/146034628-38783cb4-2880-4eb1-9c40-75c181a417ec.png)
After:
![after](https://user-images.githubusercontent.com/17001771/146034625-cb1095ee-6df3-436a-b5fa-194d4a58aa59.png)
