### PR TITLE
llvm: Update Bugtracker URI

### DIFF
--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -313,7 +313,7 @@ const ProjectDescriptions = () => (
               <b>Patches</b>
             </a>{" "}
             |{" "}
-            <a href="https://bugs.llvm.org/buglist.cgi?quicksearch=bpf">
+            <a href="https://github.com/llvm/llvm-project/labels/backend:BPF">
               <b>Bugtracker</b>
             </a>{" "}
           </p>


### PR DESCRIPTION
---

LLVM bugtracker has migrated  from bugs.llvm.org to GitHub issues.