### PR TITLE
Reword Projects to Landscape

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -64,7 +64,7 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
     <nav className="headerNav">
       <Link to="/what-is-ebpf">What is eBPF?</Link>
       <Link to="/blog">Blog</Link>
-      <Link to="/projects">Projects</Link>
+      <Link to="/projects">Landscape</Link>
       <span className="languageSelect">
         <button className="button" onClick={() => setIsConferencesMenuShown(!isConferencesMenuShown)} type="button">Conferences <span className="triangle">▾</span></button>
         <span className={`list${isConferencesMenuShown ? ' is-shown' : ''}`}>
@@ -137,7 +137,7 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
         <nav className="headerNav">
           <Link to="/what-is-ebpf">What is eBPF?</Link>
           <Link to="/blog">Blog</Link>
-          <Link to="/projects">Projects</Link>
+          <Link to="/projects">Landscape</Link>
           <span className="languageSelect">
             <button className="button" onClick={() => setIsConferencesMenuShown(!isConferencesMenuShown)} type="button">Conferences <span className="triangle">▾</span></button>
             <span className={`list${isConferencesMenuShown ? ' is-shown' : ''}`}>
@@ -189,7 +189,7 @@ const FooterDesktop = ({path}) => {
           Blog
         </Link>
         <Link to="/projects" className="item">
-          Projects
+          Landscape
         </Link>
         <Link to="/contribute" className="item">
           Contribute

--- a/src/pages/contribute.js
+++ b/src/pages/contribute.js
@@ -77,11 +77,10 @@ const Page = () => (
       <p>
         The list of eBPF-based projects is long and growing. It will be simple to
         find a project that sparks interest. Check out the <a
-        href="/projects">list of eBPF projects</a> to see an overview of all
-        projects.
+        href="/projects">eBPF landscape</a> to see an overview of eBPF-based projects.
       </p>
       <p>
-        Many of the listed eBPF projects maintain a list of <code>good-first-issue</code>-labeled
+        Many of the listed eBPF-based projects maintain a list of <code>good-first-issue</code>-labeled
         tasks which are scoped to not require extensive project specific knowledge and
         provide a great opportunity to get hands-on quickly.
       </p>

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -56,7 +56,7 @@ const Buttons = () => (
       What is eBPF?
     </Link>
     <Link to="/projects" className="main-button">
-      Projects
+      Landscape
     </Link>
   </h1>
 );
@@ -121,7 +121,7 @@ const Outro = () => (
                 <a href="/what-is-ebpf">What is eBPF?</a>
               </li>
               <li>
-                <a href="/projects">List of eBPF-powered projects</a>
+                <a href="/projects">eBPF Landscape</a>
               </li>
             </ul>
           </td>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -5,7 +5,7 @@ import { TitleWithAnchor } from "../common/TitleWithAnchor";
 
 import "../stylesheets/index.scss";
 
-const pageMetaTitle = 'eBPF Projects Directory'
+const pageMetaTitle = 'eBPF Landscape'
 const pageMetaDescription = 'A directory of eBPF-based open source projects'
 
 const YouMaintain = () => (
@@ -675,7 +675,7 @@ const Page = () => (
         title={pageMetaTitle}
 
         meta={[
-          {name: "keywords", content: "ebpf, bpf, projects, directory, open source"},
+          {name: "keywords", content: "ebpf, bpf, landscape, directory, open source"},
           {name: "type", property: "og:type", content: "website"},
           {name: "url", property: "og:url", content: "https://ebpf.io/contribute/"},
           {name: "title", property: "og:title", content: pageMetaTitle},


### PR DESCRIPTION
The use of the word "eBPF Projects" has raised questions whether the
listed projects require to be part of the eBPF foundation somehow. As
per charter, this is not required. The intent is to provide a landscape
of projects.

Reword the page to "eBPF Landscape" to make this clearer.

The URL is kept intact for now to not break any links. A follow-up
change can change non-content mentions of projects and set up an
URL forward.

Signed-off-by: Thomas Graf <thomas@cilium.io>