### PR TITLE
Clarify what is meant by landscape

### DIFF
--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -64,7 +64,7 @@ const HeaderDesktop = ({ language, hasLanguage, setLanguage }) => {
     <nav className="headerNav">
       <Link to="/what-is-ebpf">What is eBPF?</Link>
       <Link to="/blog">Blog</Link>
-      <Link to="/projects">Landscape</Link>
+      <Link to="/projects">Project Landscape</Link>
       <span className="languageSelect">
         <button className="button" onClick={() => setIsConferencesMenuShown(!isConferencesMenuShown)} type="button">Conferences <span className="triangle">▾</span></button>
         <span className={`list${isConferencesMenuShown ? ' is-shown' : ''}`}>
@@ -138,7 +138,7 @@ const HeaderMobile = ({ language, hasLanguage, setLanguage }) => {
         <nav className="headerNav">
           <Link to="/what-is-ebpf">What is eBPF?</Link>
           <Link to="/blog">Blog</Link>
-          <Link to="/projects">Landscape</Link>
+          <Link to="/projects">Project Landscape</Link>
           <span className="languageSelect">
             <button className="button" onClick={() => setIsConferencesMenuShown(!isConferencesMenuShown)} type="button">Conferences <span className="triangle">▾</span></button>
             <span className={`list${isConferencesMenuShown ? ' is-shown' : ''}`}>
@@ -191,7 +191,7 @@ const FooterDesktop = ({path}) => {
           Blog
         </Link>
         <Link to="/projects" className="item">
-          Landscape
+          Project Landscape
         </Link>
         <Link to="/contribute" className="item">
           Contribute

--- a/src/pages/index.en.js
+++ b/src/pages/index.en.js
@@ -56,7 +56,7 @@ const Buttons = () => (
       What is eBPF?
     </Link>
     <Link to="/projects" className="main-button">
-      Landscape
+      Project Landscape
     </Link>
   </h1>
 );

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -425,8 +425,7 @@ const ProjectDescriptions = () => (
             Major:
             <a href="https://github.com/libbpf/libbpf">
               <b>libbpf</b>
-            </a>{" "}
-            Emerging:
+            </a>
           </p>
           <p>
             libbpf is a C/C++ based library which is maintained as part of the

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -698,6 +698,12 @@ const Page = () => (
           {name: "twitter:image", content: 'https://ebpf.io' + require("../assets/ogimage.png")},
         ]}
       />
+      <p>
+        This page lists a number of open source projects that use eBPF
+        as the underlying core technology.  These projects are not under
+        the <a href="/foundation">eBPF Foundation</a> but are listed here
+        as a survey of the eBPF project landscape today.
+      </p>
       <ProjectDescriptions />
       <TitleWithAnchor headerClassName="projects-title projects-common-title">FAQ</TitleWithAnchor>
       <h3>Add your project</h3>

--- a/src/pages/projects.js
+++ b/src/pages/projects.js
@@ -5,7 +5,7 @@ import { TitleWithAnchor } from "../common/TitleWithAnchor";
 
 import "../stylesheets/index.scss";
 
-const pageMetaTitle = 'eBPF Landscape'
+const pageMetaTitle = 'eBPF Project Landscape'
 const pageMetaDescription = 'A directory of eBPF-based open source projects'
 
 const YouMaintain = () => (


### PR DESCRIPTION
In PR #164, I approved with the comment:

> I think this change is not sufficient, since it doesn't explain what is meant by "landscape". In another PR we should add such an explanation (i.e., these are not eBPF Foundation projects), and I'm happy to help with that PR.

This PR provides such an explanation.

* Change "Landscape" to "Project Landscape" for clarity (e.g., it does not contain a landscape of products that aren't open source projects)
* Add introductory text at the top of the projects page