### PR TITLE
Charter amendment: remove undefined term BSC Project

### DIFF
--- a/src/pages/charter.js
+++ b/src/pages/charter.js
@@ -180,7 +180,7 @@ const CharterPage = ({ location: {pathname} }) => {
       Related Companies. While normally members will serve two-year terms, the BSC will set
       initial term length so as to stagger elections.</p>  
         <li>One representative of any Member may observe meetings of the BSC. Any committers
-        from a BSC Project may observe meetings of the BSC. The BSC may change this at any
+        from a Technical Project may observe meetings of the BSC. The BSC may change this at any
         point in time, including: (a) opening meetings to a broader community; (b) holding closed
         meetings; and (c) holding meetings open to the public.</li>
         <li>The BSC may approve a project lifecycle policy that will address the incubation, archival


### PR DESCRIPTION
Currently the charter uses 3 different terms (Technical Project, BSC
Project, and eBPF Project) but we only have at most two concepts, not
three.  This PR changes "BSC Project" to "Technical Project" as being
the minimal possible change to address the comment.  It is hoped
that this could be approved without waiting for a conclusion regarding
any larger charter amendments.

Note that process-wise this PR requires a governing board vote before it could be merged:

> This Charter may be amended by a 70% vote of the entire Governing Board and BSC, subject to approval by The Linux Foundation.

Fixes https://github.com/ebpf-io/bsc/issues/2

Signed-off-by: Dave Thaler <dthaler@microsoft.com>